### PR TITLE
feat: add macOS Tahoe liquid glass styling with backward compatibility

### DIFF
--- a/agent-alert.xcodeproj/project.pbxproj
+++ b/agent-alert.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "thongnt.agent-alert";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -319,6 +320,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "thongnt.agent-alert";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/agent-alert/Managers/NotificationOverlayManager.swift
+++ b/agent-alert/Managers/NotificationOverlayManager.swift
@@ -18,11 +18,11 @@ class NotificationOverlayManager {
     private func createOverlayWindow() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 100),
-            styleMask: [.borderless],
+            styleMask: [.borderless, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
-        
+
         window.isOpaque = false
         window.backgroundColor = .clear
         window.level = .screenSaver
@@ -31,6 +31,8 @@ class NotificationOverlayManager {
         window.hasShadow = true
         window.acceptsMouseMovedEvents = false
         window.ignoresMouseEvents = true
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
         
         let view = NSHostingView(rootView: NotificationOverlayView())
         hostingView = view

--- a/agent-alert/Models/Notification.swift
+++ b/agent-alert/Models/Notification.swift
@@ -66,7 +66,7 @@ enum NotificationType: String, Codable, CaseIterable {
 }
 
 struct AgenticNotification: Identifiable, Codable {
-    let id = UUID()
+    var id = UUID()
     let source: NotificationSource
     let type: NotificationType
     let message: String

--- a/agent-alert/Views/NotificationOverlayView.swift
+++ b/agent-alert/Views/NotificationOverlayView.swift
@@ -3,31 +3,29 @@ import SwiftUI
 struct NotificationOverlayView: View {
     var notification: AgenticNotification?
     @State private var isAnimating = false
-    
+
     var body: some View {
         if let notification = notification {
             HStack(spacing: 16) {
-                Image(systemName: notification.source.icon)
-                    .font(.system(size: 28, weight: .medium))
-                    .foregroundColor(.white)
+                iconView(for: notification)
                     .frame(width: 44, height: 44)
-                
+
                 VStack(alignment: .leading, spacing: 4) {
                     Text(notification.source.displayName)
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.white)
-                    
+                        .foregroundStyle(.white)
+
                     Text(notification.message)
                         .font(.system(size: 13))
-                        .foregroundColor(.white.opacity(0.9))
+                        .foregroundStyle(.white.opacity(0.9))
                         .lineLimit(2)
                 }
-                
+
                 Spacer(minLength: 8)
-                
+
                 Image(systemName: notification.type.icon)
                     .font(.system(size: 22))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .scaleEffect(isAnimating ? 1.15 : 1.0)
                     .animation(
                         Animation.easeInOut(duration: 0.6)
@@ -36,28 +34,77 @@ struct NotificationOverlayView: View {
                     )
             }
             .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(
-                        LinearGradient(
-                            gradient: Gradient(colors: [
-                                Color(hex: notification.type.color),
-                                Color(hex: notification.type.color).opacity(0.85)
-                            ]),
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .shadow(color: Color.black.opacity(0.25), radius: 16, x: 0, y: 8)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
-            )
+            .notificationBackground(for: notification)
             .padding(8)
             .onAppear {
                 isAnimating = true
             }
         }
+    }
+
+    @ViewBuilder
+    private func iconView(for notification: AgenticNotification) -> some View {
+        if #available(macOS 26.0, *) {
+            Image(systemName: notification.source.icon)
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .glassEffect(.regular, in: .capsule)
+        } else {
+            Image(systemName: notification.source.icon)
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .background(
+                    Capsule()
+                        .fill(Color(hex: notification.type.color).opacity(0.3))
+                )
+        }
+    }
+}
+
+// MARK: - Platform-Specific Background Modifier
+
+struct NotificationBackgroundModifier: ViewModifier {
+    let notification: AgenticNotification
+
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content
+                .glassEffect(
+                    .regular.tint(Color(hex: notification.type.color).opacity(0.6)),
+                    in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                )
+        } else {
+            content
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.ultraThinMaterial)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(
+                            LinearGradient(
+                                gradient: Gradient(colors: [
+                                    Color(hex: notification.type.color).opacity(0.25),
+                                    Color(hex: notification.type.color).opacity(0.1)
+                                ]),
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.2), radius: 12, x: 0, y: 6)
+        }
+    }
+}
+
+extension View {
+    func notificationBackground(for notification: AgenticNotification) -> some View {
+        modifier(NotificationBackgroundModifier(notification: notification))
     }
 }


### PR DESCRIPTION
- Add native .glassEffect() for macOS 26 (Tahoe) with semantic tinting
- Provide .ultraThinMaterial fallback for macOS 15-25
- Update deployment target to macOS 15.6
- Update window style for better edge-to-edge rendering
- Change to modern .foregroundStyle() API