### PR TITLE
fix: settings window appears behind other windows

### DIFF
--- a/agent-alert/AgentAlertApp.swift
+++ b/agent-alert/AgentAlertApp.swift
@@ -19,10 +19,6 @@ struct AgentAlertApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationWillFinishLaunching(_ notification: Notification) {
-        NSApplication.shared.setActivationPolicy(.accessory)
-    }
-    
     func applicationDidFinishLaunching(_ notification: Notification) {
         URLSchemeHandler.shared.registerHandler()
         NotificationOverlayManager.shared.setup()


### PR DESCRIPTION
Remove setActivationPolicy(.accessory) which was causing the settings window to stay behind other applications. The menu bar extra with .menuBarExtraStyle(.window) already handles the menu bar behavior.