### PR TITLE
fix: settings window stays on top and centered

### DIFF
--- a/agent-alert/AgentAlertApp.swift
+++ b/agent-alert/AgentAlertApp.swift
@@ -4,17 +4,12 @@ import SwiftUI
 struct AgentAlertApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var notificationManager = NotificationManager.shared
-    
+
     var body: some Scene {
         MenuBarExtra("AgentAlert", systemImage: notificationManager.menubarIcon) {
             MenuBarView()
         }
         .menuBarExtraStyle(.window)
-        
-        Settings {
-            SettingsView()
-                .frame(width: 550, height: 500)
-        }
     }
 }
 
@@ -22,12 +17,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         URLSchemeHandler.shared.registerHandler()
         NotificationOverlayManager.shared.setup()
-        
+
         Task {
             await HTTPServerManager.shared.start()
         }
     }
-    
+
     func applicationWillTerminate(_ notification: Notification) {
         Task {
             await HTTPServerManager.shared.stop()

--- a/agent-alert/Managers/SettingsWindowManager.swift
+++ b/agent-alert/Managers/SettingsWindowManager.swift
@@ -1,0 +1,60 @@
+import Foundation
+import AppKit
+import SwiftUI
+
+class SettingsWindowManager {
+    static let shared = SettingsWindowManager()
+
+    private var settingsWindow: NSWindow?
+
+    private init() {}
+
+    func showSettings() {
+        if let existingWindow = settingsWindow {
+            existingWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        createSettingsWindow()
+    }
+
+    private func createSettingsWindow() {
+        let settingsView = SettingsView()
+            .frame(width: 550, height: 500)
+
+        let hostingController = NSHostingController(rootView: AnyView(settingsView))
+
+        // Calculate centered position
+        let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 800, height: 600)
+        let windowWidth: CGFloat = 550
+        let windowHeight: CGFloat = 500
+        let xPos = screenFrame.origin.x + (screenFrame.width - windowWidth) / 2
+        let yPos = screenFrame.origin.y + (screenFrame.height - windowHeight) / 2
+
+        let window = NSWindow(
+            contentRect: NSRect(x: xPos, y: yPos, width: windowWidth, height: windowHeight),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.title = "AgentAlert Settings"
+        window.isReleasedWhenClosed = false
+
+        // Make window float above other windows and stay visible
+        window.level = .floating
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        window.hidesOnDeactivate = false
+
+        self.settingsWindow = window
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func closeSettings() {
+        settingsWindow?.close()
+    }
+}

--- a/agent-alert/Views/MenuBarView.swift
+++ b/agent-alert/Views/MenuBarView.swift
@@ -124,7 +124,9 @@ struct MenuBarView: View {
             Spacer()
             
             HStack(spacing: 16) {
-                SettingsLink {
+                Button {
+                    SettingsWindowManager.shared.showSettings()
+                } label: {
                     Image(systemName: "gearshape")
                         .font(.system(size: 14))
                         .foregroundColor(isSettingsHovered ? .primary : .secondary)
@@ -133,7 +135,7 @@ struct MenuBarView: View {
                 .onHover { hovering in
                     isSettingsHovered = hovering
                 }
-                
+
                 Button {
                     NSApplication.shared.terminate(nil)
                 } label: {


### PR DESCRIPTION
Replace SwiftUI Settings scene with custom NSWindow for menu bar app. Window now floats above other apps and stays visible on all spaces.