### PR TITLE
feat: add system notification delivery mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ playground.xcworkspace
 # .swiftpm
 
 .build/
+build/
 
 # CocoaPods
 #

--- a/alerto.xcodeproj/project.pbxproj
+++ b/alerto.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		BA5B86FD2F3EF06500B518EC /* Alerto.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Alerto.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BA5B86FD2F3EF06500B518EC /* Alerto.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alerto.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -52,7 +52,7 @@
 		BA5B86F42F3EF06500B518EC = {
 			isa = PBXGroup;
 			children = (
-				BA5B86FF2F3EF06500B518EC /* Alerto */,
+				BA5B86FF2F3EF06500B518EC /* alerto */,
 				BA5B86FE2F3EF06500B518EC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -81,7 +81,7 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				BA5B86FF2F3EF06500B518EC /* Alerto */,
+				BA5B86FF2F3EF06500B518EC /* alerto */,
 			);
 			name = Alerto;
 			packageProductDependencies = (
@@ -107,7 +107,7 @@
 					};
 				};
 			};
-			buildConfigurationList = BA5B86F82F3EF06500B518EC /* Build configuration list for PBXProject "Alerto" */;
+			buildConfigurationList = BA5B86F82F3EF06500B518EC /* Build configuration list for PBXProject "alerto" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -281,8 +281,8 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "alerto/Info.plist";
-				"INFOPLIST_FILE[sdk=*]" = "alerto/Info.plist";
+				INFOPLIST_FILE = alerto/Info.plist;
+				"INFOPLIST_FILE[sdk=*]" = alerto/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Alerto;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -292,7 +292,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 2.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "thongnt.alerto";
+				PRODUCT_BUNDLE_IDENTIFIER = thongnt.alerto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -316,7 +316,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "alerto/Info.plist";
+				INFOPLIST_FILE = alerto/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Alerto;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -326,7 +326,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 2.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "thongnt.alerto";
+				PRODUCT_BUNDLE_IDENTIFIER = thongnt.alerto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -341,7 +341,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		BA5B86F82F3EF06500B518EC /* Build configuration list for PBXProject "Alerto" */ = {
+		BA5B86F82F3EF06500B518EC /* Build configuration list for PBXProject "alerto" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BA5B87062F3EF06600B518EC /* Debug */,

--- a/alerto/AlertoApp.swift
+++ b/alerto/AlertoApp.swift
@@ -107,8 +107,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSLog("[AppDelegate] applicationDidFinishLaunching")
+        NotificationManager.migrateLegacySettingsIfNeeded()
         URLSchemeHandler.shared.registerHandler()
         NotificationOverlayManager.shared.setup()
+        SystemNotificationService.shared.registerDelegate()
 
         // Trigger initialization by accessing the singleton
         _ = updaterManager.updaterController

--- a/alerto/Managers/NotificationManager.swift
+++ b/alerto/Managers/NotificationManager.swift
@@ -14,13 +14,35 @@ class NotificationManager: ObservableObject {
 
     @AppStorage("playSound") private var playSound = true
     @AppStorage("selectedSound") private var selectedSound = "Glass"
-    @AppStorage("showOverlay") private var showOverlaySetting = true
+    @AppStorage("notificationStyle") private var notificationStyleRaw = NotificationStyle.overlay.rawValue
     @AppStorage("overlayDuration") private var overlayDuration = 3.0
 
     private var overlayTimer: Timer?
 
+    private var notificationStyle: NotificationStyle {
+        NotificationStyle(rawValue: notificationStyleRaw) ?? .overlay
+    }
+
     private init() {}
-    
+
+    /// One-time migration from the legacy `showOverlay` boolean to `notificationStyle`.
+    /// Called from AppDelegate on launch.
+    static func migrateLegacySettingsIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: "notificationStyle") == nil else { return }
+
+        let legacy = defaults.object(forKey: "showOverlay") as? Bool
+        let migratedStyle: NotificationStyle = (legacy == false) ? .off : .overlay
+        defaults.set(migratedStyle.rawValue, forKey: "notificationStyle")
+
+        Task { @MainActor in
+            AppLogger.shared.info(
+                "Migrated showOverlay=\(legacy.map(String.init(describing:)) ?? "nil") → notificationStyle=\(migratedStyle.rawValue)",
+                category: .system
+            )
+        }
+    }
+
     func handleNotification(source: NotificationSource, type: NotificationType, message: String, hookType: HookType? = nil, rawMessage: String? = nil) {
         let notification = AgenticNotification(source: source, type: type, message: message, hookType: hookType, rawMessage: rawMessage)
         AppLogger.shared.info("Received: source=\(source.rawValue), type=\(type.rawValue), message=\(String(message.prefix(256)))", category: .notification)
@@ -30,18 +52,12 @@ class NotificationManager: ObservableObject {
             self.showNotification(notification)
         }
     }
-    
+
     private func showNotification(_ notification: AgenticNotification) {
-        currentNotification = notification
-
-        if playSound {
-            NSSound(named: NSSound.Name(selectedSound))?.play()
-            AppLogger.shared.info("Sound played: \(selectedSound)", category: .display)
-        } else {
-            AppLogger.shared.debug("Sound skipped (setting disabled)", category: .display)
-        }
-
-        if showOverlaySetting {
+        switch notificationStyle {
+        case .overlay:
+            currentNotification = notification
+            playInAppSoundIfEnabled()
             AppLogger.shared.info("Overlay shown", category: .display)
             showOverlay = true
             overlayTimer?.invalidate()
@@ -49,41 +65,62 @@ class NotificationManager: ObservableObject {
                 self?.dismissOverlay()
             }
             NotificationOverlayManager.shared.show(notification: notification, duration: overlayDuration)
-        } else {
-            AppLogger.shared.info("Overlay skipped (setting disabled)", category: .display)
-            // If overlay is disabled, just add to history immediately
-            dismissOverlay()
+
+        case .system:
+            AppLogger.shared.info("System notification posted", category: .display)
+            SystemNotificationService.shared.post(
+                notification,
+                playSound: playSound,
+                soundName: selectedSound
+            )
+            appendToHistory(notification)
+
+        case .off:
+            AppLogger.shared.info("Notification style off; history-only", category: .display)
+            appendToHistory(notification)
         }
     }
-    
+
+    private func playInAppSoundIfEnabled() {
+        if playSound {
+            NSSound(named: NSSound.Name(selectedSound))?.play()
+            AppLogger.shared.info("Sound played: \(selectedSound)", category: .display)
+        } else {
+            AppLogger.shared.debug("Sound skipped (setting disabled)", category: .display)
+        }
+    }
+
+    private func appendToHistory(_ notification: AgenticNotification) {
+        notifications.insert(notification, at: 0)
+        if notifications.count > Self.maxNotificationHistory {
+            notifications = Array(notifications.prefix(Self.maxNotificationHistory))
+        }
+        AppLogger.shared.info("Notification added to history", category: .notification)
+    }
+
     func dismissOverlay() {
         showOverlay = false
         if let notification = currentNotification {
-            notifications.insert(notification, at: 0)
-            // Enforce max history limit
-            if notifications.count > Self.maxNotificationHistory {
-                notifications = Array(notifications.prefix(Self.maxNotificationHistory))
-            }
-            AppLogger.shared.info("Notification added to history", category: .notification)
+            appendToHistory(notification)
         }
         currentNotification = nil
     }
-    
+
     func clearAll() {
         notifications.removeAll()
     }
-    
+
     func markAsRead(_ notification: AgenticNotification) {
         if let index = notifications.firstIndex(where: { $0.id == notification.id }) {
             notifications[index].isRead = true
         }
     }
-    
+
     var menubarIcon: String {
         let hasUnread = !notifications.filter { !$0.isRead }.isEmpty || currentNotification != nil
         return hasUnread ? "bell.badge.fill" : "bell.fill"
     }
-    
+
     func markAllAsRead() {
         for i in 0..<notifications.count {
             notifications[i].isRead = true

--- a/alerto/Models/Notification.swift
+++ b/alerto/Models/Notification.swift
@@ -74,6 +74,35 @@ enum HookType: String, Codable {
     case userPromptSubmit = "UserPromptSubmit"
     case permissionRequest = "PermissionRequest"
     case unknown = "unknown"
+
+    var contextTitle: String? {
+        switch self {
+        case .notification: return "Claude needs your input"
+        case .stop: return "Claude finished responding"
+        case .subagentStop: return "Subagent completed"
+        case .sessionEnd: return "Session ended"
+        case .userPromptSubmit: return "Processing your prompt"
+        case .permissionRequest: return "Permission requested"
+        case .unknown: return nil
+        }
+    }
+}
+
+/// User-selected presentation style for incoming notifications.
+enum NotificationStyle: String, CaseIterable, Identifiable {
+    case overlay
+    case system
+    case off
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .overlay: return "Overlay"
+        case .system: return "System notification"
+        case .off: return "Off"
+        }
+    }
 }
 
 struct AgenticNotification: Identifiable, Codable {
@@ -105,5 +134,14 @@ struct AgenticNotification: Identifiable, Codable {
             return String(message.prefix(maxLength)) + "..."
         }
         return message
+    }
+
+    /// Canonical display mapping shared by the overlay view and system-notification service
+    /// so titles and bodies cannot drift between presentation modes.
+    var displayContent: (title: String, subtitle: String?, body: String) {
+        if let context = hookType?.contextTitle {
+            return (title: context, subtitle: source.displayName, body: truncatedMessage)
+        }
+        return (title: source.displayName, subtitle: nil, body: truncatedMessage)
     }
 }

--- a/alerto/Services/SystemNotificationService.swift
+++ b/alerto/Services/SystemNotificationService.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Combine
+import UserNotifications
+import AppKit
+
+@MainActor
+final class SystemNotificationService: NSObject, ObservableObject {
+    static let shared = SystemNotificationService()
+
+    @Published private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    private override init() {
+        super.init()
+    }
+
+    /// Wires the delegate and seeds the cached authorization status.
+    func registerDelegate() {
+        UNUserNotificationCenter.current().delegate = self
+        refreshAuthorizationStatus()
+    }
+
+    func refreshAuthorizationStatus() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            Task { @MainActor in
+                SystemNotificationService.shared.authorizationStatus = settings.authorizationStatus
+            }
+        }
+    }
+
+    /// Triggers the system prompt only when status is undetermined. No-op otherwise.
+    func requestAuthorizationIfNeeded() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            Task { @MainActor in
+                SystemNotificationService.shared.authorizationStatus = settings.authorizationStatus
+            }
+            guard settings.authorizationStatus == .notDetermined else { return }
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+                Task { @MainActor in
+                    SystemNotificationService.shared.refreshAuthorizationStatus()
+                    if let error = error {
+                        AppLogger.shared.error("System notification authorization error: \(error.localizedDescription)", category: .notification)
+                    } else {
+                        AppLogger.shared.info("System notification authorization granted=\(granted)", category: .notification)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Posts a notification through UNUserNotificationCenter. Sound is delegated to
+    /// UNNotificationSound so macOS Focus / DND can suppress it correctly.
+    func post(_ notification: AgenticNotification, playSound: Bool, soundName: String) {
+        requestAuthorizationIfNeeded()
+
+        let parts = notification.displayContent
+        let content = UNMutableNotificationContent()
+        content.title = parts.title
+        if let subtitle = parts.subtitle {
+            content.subtitle = subtitle
+        }
+        content.body = parts.body
+        content.sound = playSound ? UNNotificationSound(named: UNNotificationSoundName(soundName)) : nil
+        content.userInfo = ["alertoNotificationID": notification.id.uuidString]
+
+        let request = UNNotificationRequest(
+            identifier: notification.id.uuidString,
+            content: content,
+            trigger: nil
+        )
+
+        UNUserNotificationCenter.current().add(request) { error in
+            Task { @MainActor in
+                if let error = error {
+                    AppLogger.shared.error("System notification post failed: \(error.localizedDescription)", category: .notification)
+                } else {
+                    AppLogger.shared.info("System notification posted", category: .display)
+                }
+            }
+        }
+    }
+}
+
+extension SystemNotificationService: UNUserNotificationCenterDelegate {
+    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                            willPresent notification: UNNotification,
+                                            withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound])
+    }
+
+    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                            didReceive response: UNNotificationResponse,
+                                            withCompletionHandler completionHandler: @escaping () -> Void) {
+        DispatchQueue.main.async {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        completionHandler()
+    }
+}

--- a/alerto/Views/NotificationOverlayView.swift
+++ b/alerto/Views/NotificationOverlayView.swift
@@ -6,24 +6,23 @@ struct NotificationOverlayView: View {
 
     var body: some View {
         if let notification = notification {
+            let content = notification.displayContent
             HStack(spacing: 16) {
                 iconView(for: notification)
                     .frame(width: 44, height: 44)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    // Show hook type context if available
-                    if let hookType = notification.hookType, hookType != .unknown {
-                        Text(hookContextTitle(for: hookType))
+                    if let subtitle = content.subtitle {
+                        Text(subtitle)
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(.white.opacity(0.7))
                     }
 
-                    Text(notification.source.displayName)
+                    Text(content.title)
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(.white)
 
-                    // Show truncated message content
-                    Text(notification.truncatedMessage)
+                    Text(content.body)
                         .font(.system(size: 13))
                         .foregroundStyle(.white.opacity(0.9))
                         .lineLimit(3)
@@ -70,25 +69,6 @@ struct NotificationOverlayView: View {
         }
     }
 
-    /// Returns a human-readable context title based on the hook type
-    private func hookContextTitle(for hookType: HookType) -> String {
-        switch hookType {
-        case .notification:
-            return "Claude needs your input"
-        case .stop:
-            return "Claude finished responding"
-        case .subagentStop:
-            return "Subagent completed"
-        case .sessionEnd:
-            return "Session ended"
-        case .userPromptSubmit:
-            return "Processing your prompt"
-        case .permissionRequest:
-            return "Permission requested"
-        case .unknown:
-            return ""
-        }
-    }
 }
 
 // MARK: - Platform-Specific Background Modifier

--- a/alerto/Views/SettingsView.swift
+++ b/alerto/Views/SettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Sparkle
 import ServiceManagement
+import UserNotifications
 
 struct SettingsView: View {
     var body: some View {
@@ -31,14 +32,27 @@ struct SettingsView: View {
 }
 
 struct GeneralSettingsView: View {
-    @AppStorage("showOverlay") private var showOverlay = true
+    @AppStorage("notificationStyle") private var notificationStyleRaw = NotificationStyle.overlay.rawValue
     @AppStorage("overlayDuration") private var overlayDuration = 3.0
     @AppStorage("playSound") private var playSound = true
     @AppStorage("selectedSound") private var selectedSound = "Glass"
 
     @StateObject private var serverManager = HTTPServerManager.shared
     @StateObject private var launchAtLoginService = LaunchAtLoginService.shared
+    @StateObject private var systemNotificationService = SystemNotificationService.shared
     @State private var portString: String = ""
+
+    private var notificationStyle: Binding<NotificationStyle> {
+        Binding(
+            get: { NotificationStyle(rawValue: notificationStyleRaw) ?? .overlay },
+            set: { newValue in
+                notificationStyleRaw = newValue.rawValue
+                if newValue == .system {
+                    systemNotificationService.requestAuthorizationIfNeeded()
+                }
+            }
+        )
+    }
 
     let availableSounds = ["Glass", "Ping", "Pop", "Purr", "Blow", "Hero", "Submarine"]
 
@@ -68,16 +82,44 @@ struct GeneralSettingsView: View {
             }
 
             Section("Notifications") {
-                Toggle("Show overlay notification", isOn: $showOverlay)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Overlay duration")
-                        Spacer()
-                        Text("\(Int(overlayDuration))s")
-                            .foregroundColor(.secondary)
+                Picker("Notification style", selection: notificationStyle) {
+                    ForEach(NotificationStyle.allCases) { style in
+                        Text(style.displayName).tag(style)
                     }
-                    Slider(value: $overlayDuration, in: 1...10, step: 1)
+                }
+                .pickerStyle(.menu)
+
+                Text("System notifications respect Focus and Do Not Disturb.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                if notificationStyle.wrappedValue == .overlay {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Overlay duration")
+                            Spacer()
+                            Text("\(Int(overlayDuration))s")
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: $overlayDuration, in: 1...10, step: 1)
+                    }
+                }
+
+                if notificationStyle.wrappedValue == .system,
+                   systemNotificationService.authorizationStatus == .denied {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Notifications are disabled for Alerto.")
+                                .font(.caption)
+                            Button("Open Notification Settings") {
+                                openNotificationSettings()
+                            }
+                            .buttonStyle(.link)
+                            .font(.caption)
+                        }
+                    }
                 }
             }
 
@@ -148,11 +190,18 @@ struct GeneralSettingsView: View {
         .onAppear {
             portString = String(serverManager.port)
             launchAtLoginService.refreshStatus()
+            systemNotificationService.refreshAuthorizationStatus()
         }
     }
 
     private func openLoginItemsSettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func openNotificationSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?Alerto") {
             NSWorkspace.shared.open(url)
         }
     }

--- a/openspec/changes/archive/2026-05-08-add-system-notifications/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-08-add-system-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/archive/2026-05-08-add-system-notifications/design.md
+++ b/openspec/changes/archive/2026-05-08-add-system-notifications/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Alerto is a macOS menu bar app (`LSUIElement = true`) that today renders every alert through a custom `NotificationOverlayView`/`NotificationOverlayManager`. The overlay path is the only delivery surface, controlled by a single `@AppStorage("showOverlay")` boolean and an `overlayDuration` slider in `SettingsView`. Sound is played manually via `NSSound` from `NotificationManager.showNotification`. The app is signed (Sparkle EdDSA) and not sandboxed (no `.entitlements` file).
+
+Constraint: a menu bar app receives alerts from background HTTP hooks at any time, including while the user is in another full-screen app or has macOS Focus modes enabled. The overlay ignores Focus and steals attention. We need an OS-native delivery path that respects user system policy, while keeping the existing overlay mode for users who prefer it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a `UNUserNotificationCenter`-based delivery mode selectable from Settings.
+- Preserve existing default behavior for current users (overlay remains the default and migrates cleanly from the old boolean).
+- Reuse existing notification content (title/body derived from `AgenticNotification`, source, hook type) and existing sound preference.
+- Handle authorization gracefully: lazy request, clear in-app feedback when denied.
+- Keep notification history in-app regardless of presentation mode.
+
+**Non-Goals:**
+- Custom notification actions / reply buttons (future work).
+- Cross-device push relay (separate proposal).
+- Per-project routing rules (separate proposal).
+- Replacing or removing the overlay implementation.
+- Sandbox migration.
+
+## Decisions
+
+### 1. Three-mode selector instead of a per-mode toggle pair
+A single enum-backed `notificationStyle` setting with values `overlay | system | off` keeps the modes mutually exclusive and avoids the "both on" ambiguity (double notifications, double sound). The current `showOverlay: Bool` is migrated on first launch: `true → overlay`, `false → off`. New users default to `overlay` to preserve install-day parity.
+
+Alternative considered: two booleans (`showOverlay`, `useSystemNotifications`). Rejected — invites contradictory states and complicates the sound-suppression rule below.
+
+### 2. Sound ownership moves with the mode
+- `overlay` and `off`: keep current `NSSound(named:).play()` in `NotificationManager`.
+- `system`: pass `UNNotificationSound(named: NSSound.Name(selectedSound))` on the `UNMutableNotificationContent`. The manual `NSSound` call is **suppressed** in this branch.
+
+Rationale: the OS plays a notification sound when banners deliver, and Focus/DND silence it correctly. Playing `NSSound` ourselves on top would double-play and bypass DND.
+
+### 3. New `SystemNotificationService` singleton in `alerto/Services/`
+Wraps `UNUserNotificationCenter.current()`. Responsibilities:
+- Lazy `requestAuthorization(options: [.alert, .sound])` on first `post(...)` call; cache last-known status in a `@Published var authorizationStatus: UNAuthorizationStatus`.
+- Build `UNMutableNotificationContent` from an `AgenticNotification` using the same title/body rules as the overlay (reuse a small helper extracted from existing display logic so the two paths can't drift).
+- Schedule with a nil trigger (deliver immediately).
+- Conform to `UNUserNotificationCenterDelegate`:
+  - `willPresent` → return `[.banner, .sound]` so notifications still appear when the menu bar window is open.
+  - `didReceive` (tap) → reopen Settings or focus menu bar (use existing `SettingsWindowManager` for now; tap-to-focus a specific notification is out of scope).
+
+Alternative considered: keep this inline in `NotificationManager`. Rejected — `NotificationManager` already mixes state, sound, overlay, and history; adding UNC delegate duties makes it harder to test and reason about.
+
+### 4. Branch in `NotificationManager.showNotification` on style
+```
+switch notificationStyle {
+case .overlay:        currentNotification = ...; play NSSound; show overlay
+case .system:         SystemNotificationService.shared.post(notification); append to history directly (no currentNotification gating)
+case .off:            append to history only
+}
+```
+History append for `.system` happens immediately because there is no in-app dismiss event to drive the existing `dismissOverlay()` flow. The menu bar unread badge logic (`menubarIcon`) continues to work via the `notifications` array.
+
+### 5. Authorization UX
+- First time the user picks `system` mode, requesting authorization will trigger the macOS prompt. We don't pre-request on launch — keeps cold-start clean for users who never opt in.
+- If `authorizationStatus == .denied`, the Settings General → Notifications section shows an inline warning row with a "Open Notification Settings" button that opens `x-apple.systempreferences:com.apple.Notifications-Settings.extension?Alerto`. The `system` mode remains selectable; we don't silently fall back, so the user understands why they're not seeing banners.
+- Status is refreshed when the Settings window appears (`getNotificationSettings`).
+
+### 6. No new entitlements / Info.plist changes
+`UNUserNotificationCenter` for **local** notifications on macOS does not require sandbox entitlements or aps-environment configuration; the existing signed bundle is sufficient. We are not using remote (push) notifications.
+
+## Risks / Trade-offs
+
+- **Authorization denied without remediation** → Mitigation: explicit inline warning in Settings + deep link to System Settings; never silently swallow the denial.
+- **Behavior surprise: alerts swallowed by Focus/DND** → Mitigation: brief help text under the style picker explaining "System notifications respect Focus and Do Not Disturb." Users who want guaranteed visibility keep the overlay mode.
+- **Title/body divergence between overlay and system paths** → Mitigation: extract a single `displayContent(for: AgenticNotification) -> (title, body, subtitle?)` helper used by both paths.
+- **Double sound during transitions / race conditions** → Mitigation: sound branching is centralized in `NotificationManager.showNotification`, gated by the mode enum, with no other call site invoking `NSSound`.
+- **Notification Center backlog** when user is away → Acceptable: this is exactly the behavior users opting into system mode want. We do not throttle or coalesce in this change.
+- **Migration regressions for users with `showOverlay = false`** → They were getting silent history-only behavior; mapping to `off` preserves that. We log the migration once for diagnostics.
+
+## Migration Plan
+
+1. On first launch after upgrade, `NotificationManager` (or a small `SettingsMigration` helper called from `AppDelegate.applicationDidFinishLaunching`) checks for the absence of `notificationStyle` in `UserDefaults` and the presence of `showOverlay`:
+   - `showOverlay == true` (or unset) → write `notificationStyle = "overlay"`.
+   - `showOverlay == false` → write `notificationStyle = "off"`.
+   - Keep the old `showOverlay` key in place for one release (do not delete) so a downgrade still works.
+2. No data migration is needed for notification history.
+3. Rollback: revert the binary; the old `showOverlay` key is still present and honored by the prior version.
+
+## Open Questions
+
+- Should tapping a system notification open Settings, focus the menu bar popover, or do nothing? Initial decision: open the menu bar popover if reachable, fall back to no-op. Revisit after user feedback.
+- Should we expose `interruptionLevel` (active/timeSensitive) as a power-user setting? Out of scope for this change; default is `.active`.

--- a/openspec/changes/archive/2026-05-08-add-system-notifications/proposal.md
+++ b/openspec/changes/archive/2026-05-08-add-system-notifications/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The current overlay-only presentation interrupts the user's screen, ignores macOS Focus / Do Not Disturb, and disappears after a fixed timeout with no way to recover the alert from Notification Center. Users who want quieter, OS-native delivery (and history that survives in Notification Center) have no option today.
+
+## What Changes
+
+- Add a new presentation mode that delivers alerts through `UNUserNotificationCenter` so they appear as native macOS banners/alerts and stack in Notification Center.
+- Replace the boolean "Show overlay notification" toggle in Settings with a three-way notification style: **Overlay**, **System notification**, **Off**. Existing users keep "Overlay" behavior (migrated from the prior `showOverlay` bool).
+- When System notification is selected, sound playback is delegated to `UNNotificationSound` using the existing selected sound; the in-app `NSSound` fallback is suppressed in that mode to prevent double-play.
+- Request notification authorization lazily on first use, and surface an inline warning + deep link to System Settings → Notifications if authorization is denied.
+- Hide the overlay-duration slider when style ≠ Overlay.
+- Notifications continue to be appended to in-app history regardless of style (parity with current "Off" path).
+
+## Capabilities
+
+### New Capabilities
+- `system-notification-display`: Deliver Alerto notifications via macOS `UNUserNotificationCenter`, including authorization handling, content mapping, sound, and tap behavior.
+
+### Modified Capabilities
+- `notification-content-display`: Notification presentation is no longer overlay-only; the existing content rules (title/body/subtitle, hook-type context, message truncation) MUST apply to the new system-notification path as well, and the user-visible setting is now a style selector rather than a single toggle.
+
+## Impact
+
+- **Code**: `alerto/Managers/NotificationManager.swift` (branch on style), new `alerto/Services/SystemNotificationService.swift`, `alerto/Views/SettingsView.swift` (style picker + permission UX), one-time migration of `@AppStorage("showOverlay")` → `@AppStorage("notificationStyle")`.
+- **Frameworks**: Adds `UserNotifications` framework usage. No new third-party dependencies.
+- **Entitlements / Info.plist**: No sandbox entitlements required (app is not sandboxed). `UNUserNotificationCenter` works for the existing signed bundle; no Info.plist keys are required for local user notifications on macOS.
+- **User-visible behavior**: Authorization prompt appears the first time a user switches to System notification mode. Users on macOS Focus/DND will stop seeing alerts in that mode — by design.
+- **Backward compatibility**: Default mode remains overlay; users who previously had `showOverlay = false` are migrated to the new "Off" mode.

--- a/openspec/changes/archive/2026-05-08-add-system-notifications/specs/notification-content-display/spec.md
+++ b/openspec/changes/archive/2026-05-08-add-system-notifications/specs/notification-content-display/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Display hook message in notification
 The system SHALL display the actual message content from Claude Code hooks in notifications instead of hardcoded messages, for both overlay and system-notification presentation modes.

--- a/openspec/changes/archive/2026-05-08-add-system-notifications/specs/system-notification-display/spec.md
+++ b/openspec/changes/archive/2026-05-08-add-system-notifications/specs/system-notification-display/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Notification style selector
+The system SHALL provide a user-facing setting that selects exactly one notification presentation style from `overlay`, `system`, or `off`.
+
+#### Scenario: Overlay mode selected
+- **WHEN** the user selects "Overlay" in Settings → General → Notifications
+- **THEN** incoming notifications are displayed using the in-app overlay window and no system notification is posted
+
+#### Scenario: System mode selected
+- **WHEN** the user selects "System notification" in Settings → General → Notifications
+- **THEN** incoming notifications are delivered via `UNUserNotificationCenter` and no overlay window is shown
+
+#### Scenario: Off mode selected
+- **WHEN** the user selects "Off" in Settings → General → Notifications
+- **THEN** no overlay is shown and no system notification is posted, but the notification is still appended to in-app history
+
+#### Scenario: Default for new installs
+- **WHEN** the app is launched for the first time with no prior `notificationStyle` setting and no prior `showOverlay` setting
+- **THEN** the style defaults to `overlay`
+
+### Requirement: Migrate legacy showOverlay setting
+The system SHALL migrate the previous `showOverlay` boolean preference to the new `notificationStyle` setting on first launch after upgrade.
+
+#### Scenario: Legacy enabled
+- **WHEN** the app launches and `notificationStyle` is unset and `showOverlay` is `true`
+- **THEN** `notificationStyle` is set to `overlay`
+
+#### Scenario: Legacy disabled
+- **WHEN** the app launches and `notificationStyle` is unset and `showOverlay` is `false`
+- **THEN** `notificationStyle` is set to `off`
+
+### Requirement: Deliver via UNUserNotificationCenter
+The system SHALL deliver notifications through `UNUserNotificationCenter` when style is `system`, including when the menu bar window is open.
+
+#### Scenario: Banner appears while app is foregrounded
+- **WHEN** style is `system` and a notification is received while the user has the menu bar popover open
+- **THEN** the notification still appears as a banner (presentation options include `.banner` and `.sound`)
+
+#### Scenario: Notification persists in Notification Center
+- **WHEN** style is `system` and a notification is delivered
+- **THEN** the notification is retrievable from macOS Notification Center until the user dismisses it
+
+### Requirement: Lazy authorization request
+The system SHALL request notification authorization only when first needed, not at app launch.
+
+#### Scenario: First post in system mode triggers prompt
+- **WHEN** style is `system`, authorization status is `notDetermined`, and a notification needs to be delivered
+- **THEN** the system requests authorization with `.alert` and `.sound` options before posting
+
+#### Scenario: No prompt while in overlay or off mode
+- **WHEN** the user remains in `overlay` or `off` mode for the entire session
+- **THEN** the system does not request notification authorization
+
+### Requirement: Surface denied authorization
+The system SHALL inform the user when notification authorization is denied while `system` mode is selected.
+
+#### Scenario: Inline warning shown in Settings
+- **WHEN** style is `system` and authorization status is `denied`
+- **THEN** Settings → General → Notifications displays an inline warning with a button to open System Settings → Notifications
+
+#### Scenario: Mode remains selectable
+- **WHEN** authorization is denied
+- **THEN** the system does not silently change the user's selected style; the selection remains `system`
+
+### Requirement: Sound delegation by mode
+The system SHALL play notification sound through exactly one mechanism per mode to avoid double-play.
+
+#### Scenario: Overlay mode plays in-app sound
+- **WHEN** style is `overlay` and `playSound` is enabled
+- **THEN** `NSSound(named: selectedSound)` is played by the app
+
+#### Scenario: System mode delegates to UNNotificationSound
+- **WHEN** style is `system` and `playSound` is enabled
+- **THEN** the posted `UNMutableNotificationContent` carries `UNNotificationSound(named: selectedSound)` and the app does not call `NSSound.play`
+
+#### Scenario: Sound disabled
+- **WHEN** `playSound` is disabled
+- **THEN** no sound is played in any mode and `UNNotificationContent.sound` is `nil` in `system` mode
+
+### Requirement: History parity across modes
+The system SHALL append every received notification to in-app history regardless of the selected style.
+
+#### Scenario: System mode adds to history
+- **WHEN** style is `system` and a notification is delivered
+- **THEN** the notification appears in the menu bar history list with the same metadata as overlay-mode entries
+
+#### Scenario: Off mode adds to history
+- **WHEN** style is `off` and a notification is received
+- **THEN** the notification still appears in the menu bar history list
+
+### Requirement: Tapping a system notification activates the app
+The system SHALL bring Alerto's interface to the foreground when the user taps a delivered system notification.
+
+#### Scenario: Tap activates menu bar
+- **WHEN** the user taps a delivered system notification
+- **THEN** the app activates and the menu bar popover is shown if available
+
+### Requirement: Hide overlay duration when not in overlay mode
+The system SHALL hide or disable the overlay-duration control when the selected style is not `overlay`.
+
+#### Scenario: Slider hidden in system mode
+- **WHEN** the selected style is `system` or `off`
+- **THEN** the "Overlay duration" slider is not shown in Settings

--- a/openspec/changes/archive/2026-05-08-add-system-notifications/tasks.md
+++ b/openspec/changes/archive/2026-05-08-add-system-notifications/tasks.md
@@ -1,0 +1,49 @@
+## 1. Settings model & migration
+
+- [x] 1.1 Define `NotificationStyle` enum (`overlay`, `system`, `off`) with a `rawValue: String` representation suitable for `@AppStorage`
+- [x] 1.2 Add `@AppStorage("notificationStyle")` reads in `NotificationManager` and `SettingsView` (default `overlay`)
+- [x] 1.3 Implement one-time migration from `@AppStorage("showOverlay")` → `notificationStyle` in `AppDelegate.applicationDidFinishLaunching` (true → overlay, false → off, missing → overlay)
+- [x] 1.4 Log the migration outcome once via `AppLogger`
+
+## 2. SystemNotificationService
+
+- [x] 2.1 Create `alerto/Services/SystemNotificationService.swift` as a `@MainActor` singleton wrapping `UNUserNotificationCenter.current()`
+- [x] 2.2 Add `@Published var authorizationStatus: UNAuthorizationStatus` and a `refreshAuthorizationStatus()` method using `getNotificationSettings`
+- [x] 2.3 Implement `requestAuthorizationIfNeeded()` that calls `requestAuthorization(options: [.alert, .sound])` only when status is `.notDetermined`
+- [x] 2.4 Implement `post(_ notification: AgenticNotification, playSound: Bool, soundName: String)` that builds `UNMutableNotificationContent` (title/subtitle/body via shared content helper) and submits a `UNNotificationRequest` with nil trigger
+- [x] 2.5 Conform to `UNUserNotificationCenterDelegate` and register on app launch:
+  - `willPresent` → completion handler returns `[.banner, .sound]`
+  - `didReceive` → activate the app (menu bar popover focus is a follow-up; tapping currently activates Alerto via `NSApp.activate`)
+- [x] 2.6 Register the delegate from `AppDelegate.applicationDidFinishLaunching`
+
+## 3. Shared content helper
+
+- [x] 3.1 Extract a `displayContent(for: AgenticNotification) -> (title: String, subtitle: String?, body: String)` helper used by both overlay and system-notification paths so titles/bodies cannot drift
+- [x] 3.2 Update `NotificationOverlayView` / `NotificationOverlayManager` to consume the shared helper (no behavior change in overlay mode)
+
+## 4. NotificationManager branching
+
+- [x] 4.1 Replace the `if showOverlaySetting` block in `NotificationManager.showNotification` with a `switch` on `NotificationStyle`
+- [x] 4.2 In `.overlay` branch: keep current behavior (NSSound + overlay + history-on-dismiss)
+- [x] 4.3 In `.system` branch: call `SystemNotificationService.shared.post(...)`, suppress `NSSound` playback, and append the notification to `notifications` history immediately
+- [x] 4.4 In `.off` branch: append to history only; no sound, no overlay
+- [x] 4.5 Verify `menubarIcon`/unread badge still updates correctly across all three modes
+
+## 5. Settings UI
+
+- [x] 5.1 Replace the "Show overlay notification" `Toggle` in `GeneralSettingsView` with a `Picker` bound to `notificationStyle` (segmented or menu) labeled "Notification style"
+- [x] 5.2 Show the "Overlay duration" slider only when `notificationStyle == .overlay`
+- [x] 5.3 Add help text under the picker noting that "System notifications respect Focus and Do Not Disturb"
+- [x] 5.4 Subscribe to `SystemNotificationService.shared.authorizationStatus`; when style is `.system` and status is `.denied`, show an inline warning row with an "Open Notification Settings" button that opens `x-apple.systempreferences:com.apple.Notifications-Settings.extension?Alerto`
+- [x] 5.5 Refresh authorization status on Settings window appear
+
+## 6. Manual verification
+
+- [x] 6.1 Fresh install: verify default style is `overlay` and `curl /notify` shows the overlay
+- [x] 6.2 Upgrade with prior `showOverlay = true`: verify migration to `overlay` and unchanged behavior
+- [x] 6.3 Upgrade with prior `showOverlay = false`: verify migration to `off` and history-only behavior
+- [x] 6.4 Switch to `system` for the first time: verify macOS authorization prompt appears, then a `curl /notify` produces a banner
+- [x] 6.5 Deny authorization in System Settings → verify inline warning appears in Settings and selection remains `system`
+- [x] 6.6 With `system` selected and `playSound` enabled, confirm only one sound plays (no double-play)
+- [x] 6.7 With `system` selected, enable a Focus mode → verify banner is suppressed by macOS and the entry still appears in app history
+- [x] 6.8 Tap a delivered system notification → verify Alerto activates

--- a/openspec/specs/system-notification-display/spec.md
+++ b/openspec/specs/system-notification-display/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Notification style selector
+The system SHALL provide a user-facing setting that selects exactly one notification presentation style from `overlay`, `system`, or `off`.
+
+#### Scenario: Overlay mode selected
+- **WHEN** the user selects "Overlay" in Settings → General → Notifications
+- **THEN** incoming notifications are displayed using the in-app overlay window and no system notification is posted
+
+#### Scenario: System mode selected
+- **WHEN** the user selects "System notification" in Settings → General → Notifications
+- **THEN** incoming notifications are delivered via `UNUserNotificationCenter` and no overlay window is shown
+
+#### Scenario: Off mode selected
+- **WHEN** the user selects "Off" in Settings → General → Notifications
+- **THEN** no overlay is shown and no system notification is posted, but the notification is still appended to in-app history
+
+#### Scenario: Default for new installs
+- **WHEN** the app is launched for the first time with no prior `notificationStyle` setting and no prior `showOverlay` setting
+- **THEN** the style defaults to `overlay`
+
+### Requirement: Migrate legacy showOverlay setting
+The system SHALL migrate the previous `showOverlay` boolean preference to the new `notificationStyle` setting on first launch after upgrade.
+
+#### Scenario: Legacy enabled
+- **WHEN** the app launches and `notificationStyle` is unset and `showOverlay` is `true`
+- **THEN** `notificationStyle` is set to `overlay`
+
+#### Scenario: Legacy disabled
+- **WHEN** the app launches and `notificationStyle` is unset and `showOverlay` is `false`
+- **THEN** `notificationStyle` is set to `off`
+
+### Requirement: Deliver via UNUserNotificationCenter
+The system SHALL deliver notifications through `UNUserNotificationCenter` when style is `system`, including when the menu bar window is open.
+
+#### Scenario: Banner appears while app is foregrounded
+- **WHEN** style is `system` and a notification is received while the user has the menu bar popover open
+- **THEN** the notification still appears as a banner (presentation options include `.banner` and `.sound`)
+
+#### Scenario: Notification persists in Notification Center
+- **WHEN** style is `system` and a notification is delivered
+- **THEN** the notification is retrievable from macOS Notification Center until the user dismisses it
+
+### Requirement: Lazy authorization request
+The system SHALL request notification authorization only when first needed, not at app launch.
+
+#### Scenario: First post in system mode triggers prompt
+- **WHEN** style is `system`, authorization status is `notDetermined`, and a notification needs to be delivered
+- **THEN** the system requests authorization with `.alert` and `.sound` options before posting
+
+#### Scenario: No prompt while in overlay or off mode
+- **WHEN** the user remains in `overlay` or `off` mode for the entire session
+- **THEN** the system does not request notification authorization
+
+### Requirement: Surface denied authorization
+The system SHALL inform the user when notification authorization is denied while `system` mode is selected.
+
+#### Scenario: Inline warning shown in Settings
+- **WHEN** style is `system` and authorization status is `denied`
+- **THEN** Settings → General → Notifications displays an inline warning with a button to open System Settings → Notifications
+
+#### Scenario: Mode remains selectable
+- **WHEN** authorization is denied
+- **THEN** the system does not silently change the user's selected style; the selection remains `system`
+
+### Requirement: Sound delegation by mode
+The system SHALL play notification sound through exactly one mechanism per mode to avoid double-play.
+
+#### Scenario: Overlay mode plays in-app sound
+- **WHEN** style is `overlay` and `playSound` is enabled
+- **THEN** `NSSound(named: selectedSound)` is played by the app
+
+#### Scenario: System mode delegates to UNNotificationSound
+- **WHEN** style is `system` and `playSound` is enabled
+- **THEN** the posted `UNMutableNotificationContent` carries `UNNotificationSound(named: selectedSound)` and the app does not call `NSSound.play`
+
+#### Scenario: Sound disabled
+- **WHEN** `playSound` is disabled
+- **THEN** no sound is played in any mode and `UNNotificationContent.sound` is `nil` in `system` mode
+
+### Requirement: History parity across modes
+The system SHALL append every received notification to in-app history regardless of the selected style.
+
+#### Scenario: System mode adds to history
+- **WHEN** style is `system` and a notification is delivered
+- **THEN** the notification appears in the menu bar history list with the same metadata as overlay-mode entries
+
+#### Scenario: Off mode adds to history
+- **WHEN** style is `off` and a notification is received
+- **THEN** the notification still appears in the menu bar history list
+
+### Requirement: Tapping a system notification activates the app
+The system SHALL bring Alerto's interface to the foreground when the user taps a delivered system notification.
+
+#### Scenario: Tap activates menu bar
+- **WHEN** the user taps a delivered system notification
+- **THEN** the app activates and the menu bar popover is shown if available
+
+### Requirement: Hide overlay duration when not in overlay mode
+The system SHALL hide or disable the overlay-duration control when the selected style is not `overlay`.
+
+#### Scenario: Slider hidden in system mode
+- **WHEN** the selected style is `system` or `off`
+- **THEN** the "Overlay duration" slider is not shown in Settings


### PR DESCRIPTION
Replaces the binary "Show overlay notification" toggle with a three-way notification style picker (Overlay / System notification / Off). System mode delivers via UNUserNotificationCenter so alerts respect macOS Focus and Do Not Disturb and persist in Notification Center.

- New SystemNotificationService with lazy authorization, delegate, and Focus/DND-aware sound delegated to UNNotificationSound (no double-play)
- Shared AgenticNotification.displayContent helper so overlay and system paths cannot drift on title/subtitle/body
- One-time migration of legacy showOverlay bool to notificationStyle
- Settings shows inline warning + deep link when authorization is denied