### PR TITLE
feat: add quiet hours schedule

### DIFF
--- a/alerto/Managers/NotificationManager.swift
+++ b/alerto/Managers/NotificationManager.swift
@@ -16,11 +16,20 @@ class NotificationManager: ObservableObject {
     @AppStorage("selectedSound") private var selectedSound = "Glass"
     @AppStorage("notificationStyle") private var notificationStyleRaw = NotificationStyle.overlay.rawValue
     @AppStorage("overlayDuration") private var overlayDuration = 3.0
+    @AppStorage("quietHoursEnabled") private var quietHoursEnabled = false
+    @AppStorage("quietHoursStartMinutes") private var quietHoursStartMinutes = 21 * 60
+    @AppStorage("quietHoursEndMinutes") private var quietHoursEndMinutes = 9 * 60
 
     private var overlayTimer: Timer?
 
     private var notificationStyle: NotificationStyle {
         NotificationStyle(rawValue: notificationStyleRaw) ?? .overlay
+    }
+
+    private var isWithinQuietHours: Bool {
+        guard quietHoursEnabled else { return false }
+        let schedule = QuietHours(startMinutes: quietHoursStartMinutes, endMinutes: quietHoursEndMinutes)
+        return schedule.contains(Date())
     }
 
     private init() {}
@@ -54,6 +63,12 @@ class NotificationManager: ObservableObject {
     }
 
     private func showNotification(_ notification: AgenticNotification) {
+        if isWithinQuietHours {
+            AppLogger.shared.info("Quiet hours active; history-only", category: .display)
+            appendToHistory(notification)
+            return
+        }
+
         switch notificationStyle {
         case .overlay:
             currentNotification = notification

--- a/alerto/Models/QuietHours.swift
+++ b/alerto/Models/QuietHours.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// User-configured quiet hours window. Stores start/end as integer minutes
+/// since midnight so the schedule survives time zone changes and `Date` drift.
+struct QuietHours {
+    let startMinutes: Int
+    let endMinutes: Int
+
+    /// Returns true if `date` falls inside the [start, end) window.
+    /// Handles wrap-around when end is earlier than start (e.g. 21:00–09:00).
+    func contains(_ date: Date, calendar: Calendar = .current) -> Bool {
+        guard startMinutes != endMinutes else { return false }
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        let minutes = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+
+        if startMinutes < endMinutes {
+            return minutes >= startMinutes && minutes < endMinutes
+        }
+        return minutes >= startMinutes || minutes < endMinutes
+    }
+
+    /// Format `minutes` (since midnight) as a localized HH:mm string.
+    static func formatted(minutes: Int) -> String {
+        let clamped = ((minutes % (24 * 60)) + (24 * 60)) % (24 * 60)
+        let hour = clamped / 60
+        let minute = clamped % 60
+
+        var components = DateComponents()
+        components.hour = hour
+        components.minute = minute
+        if let date = Calendar.current.date(from: components) {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            formatter.dateStyle = .none
+            return formatter.string(from: date)
+        }
+        return String(format: "%02d:%02d", hour, minute)
+    }
+}

--- a/alerto/Views/SettingsView.swift
+++ b/alerto/Views/SettingsView.swift
@@ -36,6 +36,9 @@ struct GeneralSettingsView: View {
     @AppStorage("overlayDuration") private var overlayDuration = 3.0
     @AppStorage("playSound") private var playSound = true
     @AppStorage("selectedSound") private var selectedSound = "Glass"
+    @AppStorage("quietHoursEnabled") private var quietHoursEnabled = false
+    @AppStorage("quietHoursStartMinutes") private var quietHoursStartMinutes = 21 * 60
+    @AppStorage("quietHoursEndMinutes") private var quietHoursEndMinutes = 9 * 60
 
     @StateObject private var serverManager = HTTPServerManager.shared
     @StateObject private var launchAtLoginService = LaunchAtLoginService.shared
@@ -55,6 +58,21 @@ struct GeneralSettingsView: View {
     }
 
     let availableSounds = ["Glass", "Ping", "Pop", "Purr", "Blow", "Hero", "Submarine"]
+
+    private func timeBinding(for minutes: Binding<Int>) -> Binding<Date> {
+        Binding(
+            get: {
+                var components = DateComponents()
+                components.hour = minutes.wrappedValue / 60
+                components.minute = minutes.wrappedValue % 60
+                return Calendar.current.date(from: components) ?? Date()
+            },
+            set: { newDate in
+                let parts = Calendar.current.dateComponents([.hour, .minute], from: newDate)
+                minutes.wrappedValue = (parts.hour ?? 0) * 60 + (parts.minute ?? 0)
+            }
+        )
+    }
 
     var body: some View {
         Form {
@@ -120,6 +138,28 @@ struct GeneralSettingsView: View {
                             .font(.caption)
                         }
                     }
+                }
+            }
+
+            Section("Quiet Hours") {
+                Toggle("Enable quiet hours", isOn: $quietHoursEnabled)
+
+                if quietHoursEnabled {
+                    DatePicker(
+                        "From",
+                        selection: timeBinding(for: $quietHoursStartMinutes),
+                        displayedComponents: .hourAndMinute
+                    )
+
+                    DatePicker(
+                        "Until",
+                        selection: timeBinding(for: $quietHoursEndMinutes),
+                        displayedComponents: .hourAndMinute
+                    )
+
+                    Text("During quiet hours, notifications are saved to history without showing an overlay, system banner, or playing a sound.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
             }
 


### PR DESCRIPTION
## Summary

Developers who leave Alerto running overnight or during focus blocks have no built-in way to silence it short of toggling the entire notification style. This PR adds a **Quiet Hours** schedule: a user-defined daily window during which incoming notifications are saved to history only — no overlay, no system banner, no sound.

## Changes

- New `QuietHours` value type (`alerto/Models/QuietHours.swift`) with a `contains(_:)` method that handles wrap-around windows (e.g. `21:00 → 09:00`).
- `NotificationManager` now reads three new `@AppStorage` keys (`quietHoursEnabled`, `quietHoursStartMinutes`, `quietHoursEndMinutes`) and short-circuits `showNotification(_:)` to history-only when the schedule is active.
- New "Quiet Hours" section in General settings with an enable toggle and two `DatePicker`s (`hourAndMinute` mode).
- Schedule stored as integer minutes since midnight to avoid `Date` / time-zone drift.

Defaults to **disabled**; when first enabled, the window initializes to 21:00–09:00.

## Test plan

- [ ] Build: `xcodebuild -project alerto.xcodeproj -scheme Alerto -configuration Release build`
- [ ] Open Settings → General; confirm new "Quiet Hours" section with toggle.
- [ ] Enable quiet hours, set start = current time − 5min, end = current time + 5min; fire a test notification — verify it appears in the menu bar history only (no overlay, no sound).
- [ ] Disable quiet hours; verify the same notification now shows the overlay/system banner per the chosen style.
- [ ] Configure a wrap-around window (e.g. start = 23:00, end = 06:00) and verify behavior at times inside and outside it.
- [ ] Restart the app; verify the toggle and times persist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FM2zKVkiNLU81pGfUuAcne)_