### PR TITLE
[codex] Add Codex notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
   <img src="alerto/Assets.xcassets/AppIcon.imageset/AppIcon-1024.png" alt="Alerto Icon" width="128" height="128">
 </p>
 
-A macOS menu bar application that displays intelligent notifications from Claude Code without interrupting your workflow.
+A macOS menu bar application that displays intelligent notifications from Claude Code and Codex without interrupting your workflow.
 
 ## Features
 
 - **Claude Code Integration**: Receives notifications from Claude Code hooks (stop, notification, permission request, session end, etc.)
+- **Codex Integration**: Receives `Stop`, `PermissionRequest`, and `SubagentStop` lifecycle notifications
 - **Menu Bar Interface**: Accessible through system menu bar with minimal UI footprint
 - **Customizable Settings**: Configure notification sounds and display preferences
 - **Notification History**: View and manage recent notifications
@@ -22,7 +23,7 @@ Download the latest release from the [Releases page](https://github.com/thongnti
 
 ### HTTP API
 
-Alerto exposes a local HTTP server on port 7531 for receiving notifications from Claude Code:
+Alerto exposes a local HTTP server on port 7531 for receiving notifications:
 
 ```bash
 # POST notification
@@ -47,6 +48,22 @@ Add the following to your Claude Code settings to send notifications to Alerto:
   }
 }
 ```
+
+### Codex Hook Configuration
+
+Open Alerto's **Settings > Integrations** tab and install the desired Codex hooks. Alerto manages its command handlers in the user-level `~/.codex/hooks.json` file and preserves unrelated hooks and fields.
+
+Installed hooks forward Codex's stdin JSON payload to Alerto and identify the request with `source=codex`. Alerto does not modify `~/.codex/config.toml` or Codex's completion-only `notify` setting.
+
+After installing or changing hooks:
+
+1. Start a new Codex session.
+2. Run `/hooks`.
+3. Review and trust the installed Alerto hooks.
+
+Codex skips new or changed command hooks until they are trusted.
+
+See the official [Codex Hooks](https://developers.openai.com/codex/hooks) and [Advanced Configuration](https://developers.openai.com/codex/config-advanced) documentation for the lifecycle hook and configuration model.
 
 ## Configuration
 

--- a/alerto.xcodeproj/project.pbxproj
+++ b/alerto.xcodeproj/project.pbxproj
@@ -13,7 +13,18 @@
 
 /* Begin PBXFileReference section */
 		BA5B86FD2F3EF06500B518EC /* Alerto.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alerto.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0D000012F00000000000001 /* AlertoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlertoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXContainerItemProxy section */
+		C0D000022F00000000000002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BA5B86F52F3EF06500B518EC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BA5B86FC2F3EF06500B518EC;
+			remoteInfo = Alerto;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
 		E5A07FE62F667FA10079F469 /* Exceptions for "alerto" folder in "Alerto" target */ = {
@@ -34,6 +45,11 @@
 			path = alerto;
 			sourceTree = "<group>";
 		};
+		C0D000032F00000000000003 /* alertoTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = alertoTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,6 +62,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0D000042F00000000000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -53,6 +76,7 @@
 			isa = PBXGroup;
 			children = (
 				BA5B86FF2F3EF06500B518EC /* alerto */,
+				C0D000032F00000000000003 /* alertoTests */,
 				BA5B86FE2F3EF06500B518EC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -61,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				BA5B86FD2F3EF06500B518EC /* Alerto.app */,
+				C0D000012F00000000000001 /* AlertoTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -92,6 +117,29 @@
 			productReference = BA5B86FD2F3EF06500B518EC /* Alerto.app */;
 			productType = "com.apple.product-type.application";
 		};
+		C0D000052F00000000000005 /* AlertoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0D0000A2F0000000000000A /* Build configuration list for PBXNativeTarget "AlertoTests" */;
+			buildPhases = (
+				C0D000062F00000000000006 /* Sources */,
+				C0D000042F00000000000004 /* Frameworks */,
+				C0D000072F00000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C0D000082F00000000000008 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C0D000032F00000000000003 /* alertoTests */,
+			);
+			name = AlertoTests;
+			packageProductDependencies = (
+			);
+			productName = AlertoTests;
+			productReference = C0D000012F00000000000001 /* AlertoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -104,6 +152,10 @@
 				TargetAttributes = {
 					BA5B86FC2F3EF06500B518EC = {
 						CreatedOnToolsVersion = 26.2;
+					};
+					C0D000052F00000000000005 = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = BA5B86FC2F3EF06500B518EC;
 					};
 				};
 			};
@@ -126,12 +178,20 @@
 			projectRoot = "";
 			targets = (
 				BA5B86FC2F3EF06500B518EC /* Alerto */,
+				C0D000052F00000000000005 /* AlertoTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		BA5B86FB2F3EF06500B518EC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C0D000072F00000000000007 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -148,7 +208,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0D000062F00000000000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C0D000082F00000000000008 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BA5B86FC2F3EF06500B518EC /* Alerto */;
+			targetProxy = C0D000022F00000000000002 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		BA5B87062F3EF06600B518EC /* Debug */ = {
@@ -338,6 +413,36 @@
 			};
 			name = Release;
 		};
+		C0D0000B2F0000000000000B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_BUNDLE_IDENTIFIER = thongnt.alerto.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Alerto.app/Contents/MacOS/Alerto";
+			};
+			name = Debug;
+		};
+		C0D0000C2F0000000000000C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				PRODUCT_BUNDLE_IDENTIFIER = thongnt.alerto.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Alerto.app/Contents/MacOS/Alerto";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -355,6 +460,15 @@
 			buildConfigurations = (
 				BA5B87092F3EF06600B518EC /* Debug */,
 				BA5B870A2F3EF06600B518EC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C0D0000A2F0000000000000A /* Build configuration list for PBXNativeTarget "AlertoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0D0000B2F0000000000000B /* Debug */,
+				C0D0000C2F0000000000000C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/alerto.xcodeproj/xcshareddata/xcschemes/Alerto.xcscheme
+++ b/alerto.xcodeproj/xcshareddata/xcschemes/Alerto.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0D000052F00000000000005"
+               BuildableName = "AlertoTests.xctest"
+               BlueprintName = "AlertoTests"
+               ReferencedContainer = "container:alerto.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/alerto/Managers/CodexHookManager.swift
+++ b/alerto/Managers/CodexHookManager.swift
@@ -1,0 +1,256 @@
+import Foundation
+import Combine
+
+/// Manages Codex lifecycle hooks in ~/.codex/hooks.json.
+final class CodexHookManager: ObservableObject {
+    static let shared = CodexHookManager()
+
+    enum HookName: String, CaseIterable {
+        case stop = "stop"
+        case permissionRequest = "permission-request"
+        case subagentStop = "subagent-stop"
+
+        var eventName: String {
+            switch self {
+            case .stop: return "Stop"
+            case .permissionRequest: return "PermissionRequest"
+            case .subagentStop: return "SubagentStop"
+            }
+        }
+
+        var marker: String {
+            "alerto:codex-\(rawValue)"
+        }
+
+        var notificationType: String {
+            switch self {
+            case .permissionRequest: return "permission"
+            case .stop, .subagentStop: return "complete"
+            }
+        }
+    }
+
+    enum ConfigurationError: LocalizedError {
+        case invalidRoot
+        case invalidHooks
+        case invalidEvent(String)
+        case invalidMatcherGroup(String)
+        case invalidHandlers(String)
+        case invalidHandler(String)
+        case unknownHook(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidRoot:
+                return "Codex hooks.json must contain a JSON object."
+            case .invalidHooks:
+                return "Codex hooks.json contains an invalid hooks object."
+            case .invalidEvent(let event):
+                return "Codex hook event \(event) must contain an array of matcher groups."
+            case .invalidMatcherGroup(let event):
+                return "Codex hook event \(event) contains an invalid matcher group."
+            case .invalidHandlers(let event):
+                return "Codex hook event \(event) contains an invalid handlers array."
+            case .invalidHandler(let event):
+                return "Codex hook event \(event) contains an invalid handler."
+            case .unknownHook(let name):
+                return "Unknown Codex hook: \(name)."
+            }
+        }
+    }
+
+    private let fileManager: FileManager
+    private let codexHomeURL: URL
+
+    var hooksPath: URL {
+        codexHomeURL.appendingPathComponent("hooks.json")
+    }
+
+    init(
+        codexHomeURL: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex"),
+        fileManager: FileManager = .default
+    ) {
+        self.codexHomeURL = codexHomeURL
+        self.fileManager = fileManager
+    }
+
+    func isCodexInstalled() -> Bool {
+        fileManager.fileExists(atPath: codexHomeURL.path)
+    }
+
+    func isHookInstalled(name: String) -> Bool {
+        guard let hook = HookName(rawValue: name),
+              let root = try? loadConfiguration(createIfMissing: false),
+              let hooks = root["hooks"] as? [String: Any] else {
+            return false
+        }
+        return containsHandler(marker: hook.marker, in: hooks)
+    }
+
+    func isAnyHookInstalled() -> Bool {
+        guard let root = try? loadConfiguration(createIfMissing: false),
+              let hooks = root["hooks"] as? [String: Any] else {
+            return false
+        }
+        return HookName.allCases.contains { containsHandler(marker: $0.marker, in: hooks) }
+    }
+
+    func installHooks(port: Int) throws {
+        var root = try loadConfiguration(createIfMissing: true)
+        var hooks = (root["hooks"] as? [String: Any]) ?? [:]
+        for hook in HookName.allCases {
+            hooks = install(hook, port: port, into: hooks)
+        }
+        root["hooks"] = hooks
+        try saveConfiguration(root)
+    }
+
+    func installHook(name: String, port: Int) throws {
+        guard let hook = HookName(rawValue: name) else {
+            throw ConfigurationError.unknownHook(name)
+        }
+        var root = try loadConfiguration(createIfMissing: true)
+        let hooks = (root["hooks"] as? [String: Any]) ?? [:]
+        root["hooks"] = install(hook, port: port, into: hooks)
+        try saveConfiguration(root)
+    }
+
+    func uninstallHook(name: String) throws {
+        guard let hook = HookName(rawValue: name) else {
+            throw ConfigurationError.unknownHook(name)
+        }
+        try removeHandlers(markers: [hook.marker])
+    }
+
+    func uninstallHooks() throws {
+        try removeHandlers(markers: Set(HookName.allCases.map(\.marker)))
+    }
+
+    private func install(_ hook: HookName, port: Int, into hooks: [String: Any]) -> [String: Any] {
+        var updated = removingHandlers(markers: [hook.marker], from: hooks)
+        var eventGroups = (updated[hook.eventName] as? [Any]) ?? []
+        eventGroups.append([
+            "hooks": [[
+                "type": "command",
+                "command": command(for: hook, port: port),
+                "timeout": 5
+            ]]
+        ])
+        updated[hook.eventName] = eventGroups
+        return updated
+    }
+
+    private func removeHandlers(markers: Set<String>) throws {
+        guard fileManager.fileExists(atPath: hooksPath.path) else { return }
+        var root = try loadConfiguration(createIfMissing: false)
+        guard let hooks = root["hooks"] as? [String: Any] else { return }
+        let updated = removingHandlers(markers: markers, from: hooks)
+        if updated.isEmpty {
+            root.removeValue(forKey: "hooks")
+        } else {
+            root["hooks"] = updated
+        }
+        try saveConfiguration(root)
+    }
+
+    private func removingHandlers(markers: Set<String>, from hooks: [String: Any]) -> [String: Any] {
+        var updated = hooks
+        for (event, rawGroups) in hooks {
+            guard let groups = rawGroups as? [Any] else { continue }
+            var retainedGroups: [Any] = []
+
+            for rawGroup in groups {
+                guard var group = rawGroup as? [String: Any],
+                      let handlers = group["hooks"] as? [Any] else {
+                    retainedGroups.append(rawGroup)
+                    continue
+                }
+                let retainedHandlers = handlers.filter { rawHandler in
+                    guard let handler = rawHandler as? [String: Any],
+                          let command = handler["command"] as? String else {
+                        return true
+                    }
+                    return !markers.contains(where: command.contains)
+                }
+                if !retainedHandlers.isEmpty {
+                    group["hooks"] = retainedHandlers
+                    retainedGroups.append(group)
+                }
+            }
+
+            if retainedGroups.isEmpty {
+                updated.removeValue(forKey: event)
+            } else {
+                updated[event] = retainedGroups
+            }
+        }
+        return updated
+    }
+
+    private func containsHandler(marker: String, in hooks: [String: Any]) -> Bool {
+        for rawGroups in hooks.values {
+            guard let groups = rawGroups as? [Any] else { continue }
+            for rawGroup in groups {
+                guard let group = rawGroup as? [String: Any],
+                      let handlers = group["hooks"] as? [Any] else { continue }
+                for rawHandler in handlers {
+                    guard let handler = rawHandler as? [String: Any],
+                          let command = handler["command"] as? String else { continue }
+                    if command.contains(marker) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    private func command(for hook: HookName, port: Int) -> String {
+        let url = "http://127.0.0.1:\(port)/notify?source=codex&type=\(hook.notificationType)"
+        return "curl -sS --max-time 2 -X POST \"\(url)\" -H \"Content-Type: application/json\" --data-binary @- >/dev/null 2>&1 || true; printf '{}' # \(hook.marker)"
+    }
+
+    private func loadConfiguration(createIfMissing: Bool) throws -> [String: Any] {
+        guard fileManager.fileExists(atPath: hooksPath.path) else {
+            return createIfMissing ? [:] : [:]
+        }
+
+        let data = try Data(contentsOf: hooksPath)
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let root = json as? [String: Any] else {
+            throw ConfigurationError.invalidRoot
+        }
+        try validate(root)
+        return root
+    }
+
+    private func validate(_ root: [String: Any]) throws {
+        guard let rawHooks = root["hooks"] else { return }
+        guard let hooks = rawHooks as? [String: Any] else {
+            throw ConfigurationError.invalidHooks
+        }
+        for (event, rawGroups) in hooks {
+            guard let groups = rawGroups as? [Any] else {
+                throw ConfigurationError.invalidEvent(event)
+            }
+            for rawGroup in groups {
+                guard let group = rawGroup as? [String: Any] else {
+                    throw ConfigurationError.invalidMatcherGroup(event)
+                }
+                guard let rawHandlers = group["hooks"],
+                      let handlers = rawHandlers as? [Any] else {
+                    throw ConfigurationError.invalidHandlers(event)
+                }
+                guard handlers.allSatisfy({ $0 is [String: Any] }) else {
+                    throw ConfigurationError.invalidHandler(event)
+                }
+            }
+        }
+    }
+
+    private func saveConfiguration(_ root: [String: Any]) throws {
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try fileManager.createDirectory(at: codexHomeURL, withIntermediateDirectories: true)
+        try data.write(to: hooksPath, options: .atomic)
+    }
+}

--- a/alerto/Models/Notification.swift
+++ b/alerto/Models/Notification.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum NotificationSource: String, Codable, CaseIterable {
     case claude = "claude"
+    case codex = "codex"
     case opencode = "opencode"
     case cursor = "cursor"
     case windsurf = "windsurf"
@@ -10,6 +11,7 @@ enum NotificationSource: String, Codable, CaseIterable {
     var displayName: String {
         switch self {
         case .claude: return "Claude Code"
+        case .codex: return "Codex"
         case .opencode: return "OpenCode"
         case .cursor: return "Cursor"
         case .windsurf: return "Windsurf"
@@ -20,6 +22,7 @@ enum NotificationSource: String, Codable, CaseIterable {
     var icon: String {
         switch self {
         case .claude: return "brain.head.profile"
+        case .codex: return "terminal.fill"
         case .opencode: return "chevron.left.forwardslash.chevron.right"
         case .cursor: return "cursorarrow"
         case .windsurf: return "wind"
@@ -65,7 +68,7 @@ enum NotificationType: String, Codable, CaseIterable {
     }
 }
 
-/// Represents which Claude Code hook triggered the notification
+/// Represents which agent lifecycle hook triggered the notification
 enum HookType: String, Codable {
     case notification = "Notification"
     case stop = "Stop"
@@ -75,15 +78,24 @@ enum HookType: String, Codable {
     case permissionRequest = "PermissionRequest"
     case unknown = "unknown"
 
-    var contextTitle: String? {
-        switch self {
-        case .notification: return "Claude needs your input"
-        case .stop: return "Claude finished responding"
-        case .subagentStop: return "Subagent completed"
-        case .sessionEnd: return "Session ended"
-        case .userPromptSubmit: return "Processing your prompt"
-        case .permissionRequest: return "Permission requested"
-        case .unknown: return nil
+    func contextTitle(for source: NotificationSource) -> String? {
+        if source == .codex {
+            switch self {
+            case .stop: return "Codex finished responding"
+            case .subagentStop: return "Codex subagent completed"
+            case .permissionRequest: return "Codex needs your approval"
+            case .notification, .sessionEnd, .userPromptSubmit, .unknown: return nil
+            }
+        } else {
+            switch self {
+            case .notification: return "Claude needs your input"
+            case .stop: return "Claude finished responding"
+            case .subagentStop: return "Subagent completed"
+            case .sessionEnd: return "Session ended"
+            case .userPromptSubmit: return "Processing your prompt"
+            case .permissionRequest: return "Permission requested"
+            case .unknown: return nil
+            }
         }
     }
 }
@@ -139,7 +151,7 @@ struct AgenticNotification: Identifiable, Codable {
     /// Canonical display mapping shared by the overlay view and system-notification service
     /// so titles and bodies cannot drift between presentation modes.
     var displayContent: (title: String, subtitle: String?, body: String) {
-        if let context = hookType?.contextTitle {
+        if let context = hookType?.contextTitle(for: source) {
             return (title: context, subtitle: source.displayName, body: truncatedMessage)
         }
         return (title: source.displayName, subtitle: nil, body: truncatedMessage)

--- a/alerto/Services/HTTPServerService.swift
+++ b/alerto/Services/HTTPServerService.swift
@@ -165,7 +165,7 @@ class HTTPServerManager: ObservableObject {
                 let bodyString = String(data: data, encoding: .utf8) ?? "Unable to decode body"
                 AppLogger.shared.debug("POST body: \(bodyString)", category: .http)
 
-                // First try to parse as HookPayload (new format with Claude Code hook data)
+                // First try to parse as HookPayload (agent lifecycle hook data)
                 if let hookPayload = try? JSONDecoder().decode(HookPayload.self, from: data) {
                     let hookEventName = hookPayload.hookEventName ?? hookPayload.hookType ?? "nil"
                     AppLogger.shared.info("Parsed as HookPayload: hookEventName=\(hookEventName), message=\(hookPayload.effectiveMessage)", category: .http)
@@ -281,7 +281,7 @@ private struct NotifyRequest: Codable {
     let message: String
 }
 
-/// Represents the payload from Claude Code hooks
+/// Represents a lifecycle hook payload from supported coding agents.
 struct HookPayload: Codable {
     // Top-level fields (backward compatibility)
     let source: String?
@@ -303,6 +303,9 @@ struct HookPayload: Codable {
     let hookEventName: String?
     let lastAssistantMessage: String?
     let permissionMode: String?
+    let toolName: String?
+    let toolInput: ToolInputPayload?
+    let agentType: String?
     let cwd: String?
     let transcriptPath: String?
 
@@ -316,6 +319,9 @@ struct HookPayload: Codable {
         case hookEventName = "hook_event_name"
         case lastAssistantMessage = "last_assistant_message"
         case permissionMode = "permission_mode"
+        case toolName = "tool_name"
+        case toolInput = "tool_input"
+        case agentType = "agent_type"
         case cwd
         case transcriptPath = "transcript_path"
     }
@@ -328,22 +334,36 @@ struct HookPayload: Codable {
         if let notif = notification?.message, !notif.isEmpty {
             return notif
         }
+        if (hookEventName ?? hookType)?.lowercased() == "permissionrequest",
+           let description = toolInput?.description,
+           !description.isEmpty {
+            return description
+        }
         if let msg = lastAssistantMessage, !msg.isEmpty {
             return msg
+        }
+        if let description = toolInput?.description, !description.isEmpty {
+            return description
         }
         // Fallback based on hook event name
         if let hookEvent = hookEventName ?? hookType {
             switch hookEvent.lowercased() {
             case "stop":
                 return "Task completed"
-            case "subagentstop":
-                return "Subagent completed"
             case "notification":
                 return "Claude needs your attention"
             case "sessionend":
                 return "Session ended"
             case "permissionrequest":
-                return "Permission requested"
+                if let toolName, !toolName.isEmpty {
+                    return "Approval requested for \(toolName)"
+                }
+                return "Approval requested"
+            case "subagentstop":
+                if let agentType, !agentType.isEmpty {
+                    return "\(agentType) subagent completed"
+                }
+                return "Subagent completed"
             default:
                 return "Notification from Claude Code"
             }
@@ -389,6 +409,27 @@ struct HookPayload: Codable {
 
 struct NotificationPayload: Codable {
     let message: String?
+}
+
+struct ToolInputPayload: Codable {
+    let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case description
+    }
+
+    init(from decoder: Decoder) throws {
+        guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
+            description = nil
+            return
+        }
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(description, forKey: .description)
+    }
 }
 
 private struct HealthResponse: Codable {

--- a/alerto/Views/SettingsView.swift
+++ b/alerto/Views/SettingsView.swift
@@ -222,16 +222,206 @@ struct IntegrationsSettingsView: View {
     @StateObject private var serverManager = HTTPServerManager.shared
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Integrations")
-                .font(.title2)
-                .fontWeight(.semibold)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Integrations")
+                    .font(.title2)
+                    .fontWeight(.semibold)
 
-            ClaudeCodeIntegrationView(port: serverManager.port)
+                ClaudeCodeIntegrationView(port: serverManager.port)
 
-            Spacer()
+                Divider()
+
+                CodexIntegrationView(port: serverManager.port)
+
+                Spacer()
+            }
+            .padding()
         }
-        .padding()
+    }
+}
+
+struct CodexIntegrationView: View {
+    let port: Int
+
+    @StateObject private var hookManager = CodexHookManager.shared
+    @State private var isInstalling = false
+    @State private var installError: String?
+    @State private var showActivationMessage = false
+    @State private var hookStopEnabled = false
+    @State private var hookPermissionRequestEnabled = false
+    @State private var hookSubagentStopEnabled = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Section {
+                HStack {
+                    Image(systemName: "terminal.fill")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Codex")
+                            .font(.headline)
+
+                        Text(hookStatusText)
+                            .font(.caption)
+                            .foregroundColor(hookStatusColor)
+                    }
+
+                    Spacer()
+
+                    if isInstalling {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                    }
+                }
+            }
+
+            Section("Server") {
+                HStack {
+                    Text("Port")
+                    Spacer()
+                    Text("\(port)")
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Section("Hooks") {
+                Toggle("Stop - When main turn finishes", isOn: $hookStopEnabled)
+                    .onChange(of: hookStopEnabled) { _, enabled in
+                        toggleHook("stop", enabled: enabled)
+                    }
+
+                Toggle("PermissionRequest - When approval is needed", isOn: $hookPermissionRequestEnabled)
+                    .onChange(of: hookPermissionRequestEnabled) { _, enabled in
+                        toggleHook("permission-request", enabled: enabled)
+                    }
+
+                Toggle("SubagentStop - When a subagent finishes", isOn: $hookSubagentStopEnabled)
+                    .onChange(of: hookSubagentStopEnabled) { _, enabled in
+                        toggleHook("subagent-stop", enabled: enabled)
+                    }
+            }
+            .onAppear {
+                refreshHookStates()
+            }
+
+            Section {
+                HStack {
+                    Button("Install All") {
+                        installAllHooks()
+                    }
+                    .disabled(isInstalling || allHooksEnabled)
+
+                    Button("Remove All") {
+                        removeAllHooks()
+                    }
+                    .disabled(isInstalling || !anyHookEnabled)
+                    .foregroundColor(.red)
+                }
+
+                if let installError {
+                    Text(installError)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+
+                if showActivationMessage {
+                    Text("Start a new Codex session, run /hooks, and trust the installed hooks.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+            }
+
+            Section {
+                Text("Alerto manages user-level hooks in ~/.codex/hooks.json. Codex requires new or changed hooks to be reviewed and trusted.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var hookStatusText: String {
+        if !hookManager.isCodexInstalled() {
+            return "Codex not detected"
+        }
+        if hookManager.isAnyHookInstalled() {
+            let count = [hookStopEnabled, hookPermissionRequestEnabled, hookSubagentStopEnabled].filter { $0 }.count
+            return "\(count) hook(s) installed"
+        }
+        return "No hooks installed"
+    }
+
+    private var hookStatusColor: Color {
+        if !hookManager.isCodexInstalled() {
+            return .orange
+        }
+        return hookManager.isAnyHookInstalled() ? .green : .secondary
+    }
+
+    private var allHooksEnabled: Bool {
+        hookStopEnabled && hookPermissionRequestEnabled && hookSubagentStopEnabled
+    }
+
+    private var anyHookEnabled: Bool {
+        hookStopEnabled || hookPermissionRequestEnabled || hookSubagentStopEnabled
+    }
+
+    private func refreshHookStates() {
+        hookStopEnabled = hookManager.isHookInstalled(name: "stop")
+        hookPermissionRequestEnabled = hookManager.isHookInstalled(name: "permission-request")
+        hookSubagentStopEnabled = hookManager.isHookInstalled(name: "subagent-stop")
+    }
+
+    private func toggleHook(_ name: String, enabled: Bool) {
+        isInstalling = true
+        installError = nil
+        showActivationMessage = false
+
+        do {
+            if enabled {
+                try hookManager.installHook(name: name, port: port)
+                showActivationMessage = true
+            } else {
+                try hookManager.uninstallHook(name: name)
+            }
+        } catch {
+            installError = "Failed to \(enabled ? "install" : "remove"): \(error.localizedDescription)"
+            refreshHookStates()
+        }
+
+        isInstalling = false
+    }
+
+    private func installAllHooks() {
+        isInstalling = true
+        installError = nil
+
+        do {
+            try hookManager.installHooks(port: port)
+            refreshHookStates()
+            showActivationMessage = true
+        } catch {
+            installError = "Failed to install: \(error.localizedDescription)"
+        }
+
+        isInstalling = false
+    }
+
+    private func removeAllHooks() {
+        isInstalling = true
+        installError = nil
+        showActivationMessage = false
+
+        do {
+            try hookManager.uninstallHooks()
+            refreshHookStates()
+        } catch {
+            installError = "Failed to remove: \(error.localizedDescription)"
+        }
+
+        isInstalling = false
     }
 }
 

--- a/alertoTests/CodexHookManagerTests.swift
+++ b/alertoTests/CodexHookManagerTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import Alerto
+
+@MainActor
+final class CodexHookManagerTests: XCTestCase {
+    private var temporaryDirectory: URL!
+    private var codexHome: URL!
+    private var manager: CodexHookManager!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        codexHome = temporaryDirectory.appendingPathComponent(".codex", isDirectory: true)
+        manager = CodexHookManager(codexHomeURL: codexHome)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+    }
+
+    func testInstallAllCreatesSeparateCodexMatcherGroups() throws {
+        try manager.installHooks(port: 7531)
+
+        let root = try loadRoot()
+        let hooks = try XCTUnwrap(root["hooks"] as? [String: Any])
+        XCTAssertEqual(hooks.count, 3)
+
+        for hook in CodexHookManager.HookName.allCases {
+            let groups = try XCTUnwrap(hooks[hook.eventName] as? [[String: Any]])
+            XCTAssertEqual(groups.count, 1)
+            let handlers = try XCTUnwrap(groups[0]["hooks"] as? [[String: Any]])
+            XCTAssertEqual(handlers.count, 1)
+            let command = try XCTUnwrap(handlers[0]["command"] as? String)
+            XCTAssertTrue(command.contains(hook.marker))
+            XCTAssertTrue(command.contains("source=codex&type=\(hook.notificationType)"))
+            XCTAssertTrue(command.contains("printf '{}'"))
+        }
+    }
+
+    func testReinstallIsIdempotentAndUpdatesPort() throws {
+        try manager.installHooks(port: 7531)
+        try manager.installHooks(port: 9123)
+
+        let commands = try allCommands()
+        XCTAssertEqual(commands.count, 3)
+        XCTAssertTrue(commands.allSatisfy { $0.contains(":9123/notify") })
+        XCTAssertFalse(commands.contains { $0.contains(":7531/notify") })
+    }
+
+    func testInstallPreservesUnknownFieldsAndUnrelatedHooks() throws {
+        try writeRoot([
+            "version": 7,
+            "custom": ["enabled": true],
+            "hooks": [
+                "Stop": [[
+                    "matcher": "existing",
+                    "customGroupField": "keep",
+                    "hooks": [[
+                        "type": "command",
+                        "command": "echo existing",
+                        "customHandlerField": 42
+                    ]]
+                ]],
+                "FutureEvent": [[
+                    "hooks": [["type": "command", "command": "echo future"]]
+                ]]
+            ]
+        ])
+
+        try manager.installHook(name: "stop", port: 7531)
+        let installed = try loadRoot()
+        XCTAssertEqual(installed["version"] as? Int, 7)
+        XCTAssertNotNil(installed["custom"])
+        XCTAssertTrue(try allCommands().contains("echo existing"))
+        XCTAssertTrue(try allCommands().contains("echo future"))
+
+        try manager.uninstallHook(name: "stop")
+        let removed = try loadRoot()
+        XCTAssertEqual(removed["version"] as? Int, 7)
+        XCTAssertTrue(try allCommands().contains("echo existing"))
+        XCTAssertTrue(try allCommands().contains("echo future"))
+        XCTAssertFalse(manager.isAnyHookInstalled())
+    }
+
+    func testBulkRemovalOnlyRemovesAlertoHandlers() throws {
+        try manager.installHooks(port: 7531)
+        var root = try loadRoot()
+        var hooks = try XCTUnwrap(root["hooks"] as? [String: Any])
+        hooks["Stop"] = (hooks["Stop"] as? [Any] ?? []) + [[
+            "hooks": [["type": "command", "command": "echo user-hook"]]
+        ]]
+        root["hooks"] = hooks
+        try writeRoot(root)
+
+        try manager.uninstallHooks()
+
+        XCTAssertEqual(try allCommands(), ["echo user-hook"])
+        XCTAssertFalse(manager.isAnyHookInstalled())
+    }
+
+    func testMalformedConfigurationIsNotOverwritten() throws {
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        let malformed = Data(#"{"hooks":{"Stop":"invalid"}}"#.utf8)
+        try malformed.write(to: manager.hooksPath)
+
+        XCTAssertThrowsError(try manager.installHooks(port: 7531))
+        XCTAssertEqual(try Data(contentsOf: manager.hooksPath), malformed)
+    }
+
+    private func loadRoot() throws -> [String: Any] {
+        let data = try Data(contentsOf: manager.hooksPath)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func writeRoot(_ root: [String: Any]) throws {
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: manager.hooksPath)
+    }
+
+    private func allCommands() throws -> [String] {
+        let root = try loadRoot()
+        let hooks = try XCTUnwrap(root["hooks"] as? [String: Any])
+        return hooks.values.flatMap { rawGroups -> [String] in
+            guard let groups = rawGroups as? [[String: Any]] else { return [] }
+            return groups.flatMap { group -> [String] in
+                guard let handlers = group["hooks"] as? [[String: Any]] else { return [] }
+                return handlers.compactMap { $0["command"] as? String }
+            }
+        }
+    }
+}

--- a/alertoTests/HookPayloadTests.swift
+++ b/alertoTests/HookPayloadTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Alerto
+
+final class HookPayloadTests: XCTestCase {
+    func testCodexStopPayloadMapping() throws {
+        let payload = try decode(#"{"hook_event_name":"Stop","last_assistant_message":"Implemented the change."}"#)
+        XCTAssertEqual(payload.effectiveMessage, "Implemented the change.")
+        XCTAssertEqual(payload.effectiveType, "complete")
+        XCTAssertEqual(payload.effectiveHookType, .stop)
+    }
+
+    func testCodexPermissionRequestUsesDescriptionThenToolFallback() throws {
+        let described = try decode(#"{"hook_event_name":"PermissionRequest","tool_name":"Bash","last_assistant_message":"Older context","tool_input":{"description":"Run the release command"}}"#)
+        XCTAssertEqual(described.effectiveMessage, "Run the release command")
+        XCTAssertEqual(described.effectiveType, "permission")
+        XCTAssertEqual(described.effectiveHookType, .permissionRequest)
+
+        let fallback = try decode(#"{"hook_event_name":"PermissionRequest","tool_name":"apply_patch","tool_input":{}}"#)
+        XCTAssertEqual(fallback.effectiveMessage, "Approval requested for apply_patch")
+
+        let nonObjectInput = try decode(#"{"hook_event_name":"PermissionRequest","tool_name":"MCP","tool_input":["arg"]}"#)
+        XCTAssertEqual(nonObjectInput.effectiveMessage, "Approval requested for MCP")
+    }
+
+    func testCodexSubagentStopUsesMessageAndAgentFallback() throws {
+        let message = try decode(#"{"hook_event_name":"SubagentStop","agent_type":"reviewer","last_assistant_message":"Review complete."}"#)
+        XCTAssertEqual(message.effectiveMessage, "Review complete.")
+        XCTAssertEqual(message.effectiveType, "complete")
+        XCTAssertEqual(message.effectiveHookType, .subagentStop)
+
+        let fallback = try decode(#"{"hook_event_name":"SubagentStop","agent_type":"reviewer"}"#)
+        XCTAssertEqual(fallback.effectiveMessage, "reviewer subagent completed")
+    }
+
+    func testClaudePayloadAndTitlesRemainUnchanged() throws {
+        let payload = try decode(#"{"hook_event_name":"Notification","notification":{"message":"Claude is waiting"}}"#)
+        XCTAssertEqual(payload.effectiveSource, "claude")
+        XCTAssertEqual(payload.effectiveMessage, "Claude is waiting")
+        XCTAssertEqual(payload.effectiveType, "attention")
+
+        let claude = AgenticNotification(source: .claude, type: .complete, message: "Done", hookType: .stop)
+        XCTAssertEqual(claude.displayContent.title, "Claude finished responding")
+
+        let codex = AgenticNotification(source: .codex, type: .complete, message: "Done", hookType: .stop)
+        XCTAssertEqual(codex.displayContent.title, "Codex finished responding")
+        XCTAssertEqual(codex.displayContent.subtitle, "Codex")
+    }
+
+    private func decode(_ json: String) throws -> HookPayload {
+        try JSONDecoder().decode(HookPayload.self, from: Data(json.utf8))
+    }
+}

--- a/openspec/specs/codex-hook/spec.md
+++ b/openspec/specs/codex-hook/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Codex Detection
+
+The system SHALL detect Codex through the default user-level `~/.codex` directory.
+
+#### Scenario: Codex is installed
+- **WHEN** the user opens Alerto integration settings
+- **THEN** the system SHALL show Codex as detected when `~/.codex` exists
+
+### Requirement: User-Level Codex Hook Ownership
+
+The system SHALL manage Alerto handlers in `~/.codex/hooks.json` without modifying `~/.codex/config.toml` or Codex's `notify` setting.
+
+#### Scenario: Install lifecycle hooks
+- **WHEN** the user installs Codex hooks
+- **THEN** the system SHALL install separate matcher groups for `Stop`, `PermissionRequest`, and `SubagentStop`
+- **AND** each matcher group SHALL contain one Alerto command handler
+- **AND** each command SHALL contain a stable Alerto marker
+
+#### Scenario: Preserve existing configuration
+- **WHEN** Alerto updates or removes Codex hooks
+- **THEN** unrelated events, matcher groups, handlers, and unknown top-level fields SHALL remain unchanged
+
+#### Scenario: Invalid existing configuration
+- **WHEN** `hooks.json` contains malformed JSON or an invalid hook structure
+- **THEN** installation or removal SHALL fail without modifying the file
+
+#### Scenario: Atomic configuration update
+- **WHEN** Alerto writes `hooks.json`
+- **THEN** the complete configuration SHALL be replaced atomically
+
+### Requirement: Non-Blocking Codex Hook Commands
+
+The system SHALL forward Codex hook stdin payloads to Alerto without changing Codex lifecycle behavior.
+
+#### Scenario: Hook notification delivery
+- **WHEN** an installed Alerto command handler runs
+- **THEN** it SHALL POST stdin JSON to `/notify`
+- **AND** identify the request with `source=codex` and the event notification type
+- **AND** use a short HTTP timeout
+- **AND** always emit `{}` on stdout even when delivery fails
+
+### Requirement: Codex Hook Trust Guidance
+
+The system SHALL explain Codex's command-hook trust requirement after installation.
+
+#### Scenario: Hooks installed
+- **WHEN** a user installs a new or changed Codex hook
+- **THEN** Alerto SHALL instruct the user to start a new Codex session, run `/hooks`, and trust the installed hooks

--- a/openspec/specs/hook-payload-parsing/spec.md
+++ b/openspec/specs/hook-payload-parsing/spec.md
@@ -47,3 +47,18 @@ The system SHALL accept both old format (source/type/message as top-level fields
 #### Scenario: New format request with payload
 - **WHEN** request contains hook payload object
 - **THEN** system extracts message from payload
+
+### Requirement: Parse Codex lifecycle payloads
+The system SHALL parse Codex lifecycle fields without changing the existing `/notify` HTTP contract.
+
+#### Scenario: Codex permission request description
+- **WHEN** a `PermissionRequest` payload contains `tool_input.description`
+- **THEN** the system SHALL use the description as the notification message
+
+#### Scenario: Codex permission request fallback
+- **WHEN** a `PermissionRequest` payload lacks an approval description
+- **THEN** the system SHALL show a concise fallback identifying `tool_name` when available
+
+#### Scenario: Codex subagent completion
+- **WHEN** a `SubagentStop` payload contains `agent_type`
+- **THEN** the system SHALL use it in the fallback completion message when no assistant message is available

--- a/openspec/specs/multi-hook-support/spec.md
+++ b/openspec/specs/multi-hook-support/spec.md
@@ -31,3 +31,18 @@ The system SHALL determine which hook triggered the notification based on payloa
 #### Scenario: No hook type in payload
 - **WHEN** payload lacks hook type information
 - **THEN** system uses default behavior based on notification type
+
+### Requirement: Support Codex lifecycle hooks
+The system SHALL handle Codex `Stop`, `PermissionRequest`, and `SubagentStop` events.
+
+#### Scenario: Codex main turn finishes
+- **WHEN** Codex sends a `Stop` payload
+- **THEN** system displays a Codex completion notification
+
+#### Scenario: Codex needs approval
+- **WHEN** Codex sends a `PermissionRequest` payload
+- **THEN** system displays a Codex permission notification
+
+#### Scenario: Codex subagent finishes
+- **WHEN** Codex sends a `SubagentStop` payload
+- **THEN** system displays a Codex subagent completion notification

--- a/openspec/specs/notification-content-display/spec.md
+++ b/openspec/specs/notification-content-display/spec.md
@@ -32,3 +32,14 @@ The system SHALL support notification titles, bodies, and subtitles for better c
 #### Scenario: Minimal notification
 - **WHEN** only message is available
 - **THEN** the system uses the same sensible defaults for missing title/subtitle in both presentation modes
+
+### Requirement: Source-aware hook context
+The system SHALL map hook context titles according to the notification source.
+
+#### Scenario: Existing Claude notification
+- **WHEN** a Claude Code hook notification is displayed
+- **THEN** its existing Claude-specific title SHALL remain unchanged
+
+#### Scenario: Codex lifecycle notification
+- **WHEN** a Codex `Stop`, `PermissionRequest`, or `SubagentStop` notification is displayed
+- **THEN** the title SHALL identify the corresponding Codex lifecycle event


### PR DESCRIPTION
## Summary

- add first-class Codex lifecycle hook management for `Stop`, `PermissionRequest`, and `SubagentStop`
- preserve unrelated `~/.codex/hooks.json` content, validate existing structures, and write updates atomically
- add Codex-aware payload parsing, notification titles, settings controls, trust guidance, and documentation
- add a macOS XCTest target covering hook installation/removal and payload presentation behavior

## Impact

Users can install and manage Codex notifications from Alerto's Integrations settings. After installation, users must start a new Codex session, run `/hooks`, and trust the installed hooks.

## Validation

- `xcodebuild -quiet -project alerto.xcodeproj -scheme Alerto -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO`
- 9 focused tests passed
- manually verified hook commands forward stdin payloads with Codex query metadata and always output `{}` on success and failure
- `plutil -lint alerto.xcodeproj/project.pbxproj`
- `git diff --check`